### PR TITLE
Make deploy-host-backup-path optional

### DIFF
--- a/3.0/action.yml
+++ b/3.0/action.yml
@@ -111,7 +111,7 @@ runs:
     - name: Compress backup files.
       uses: appleboy/ssh-action@v0.1.4
       with:
-        script: [[ "${{inputs.deploy-host-backup-path}}" != "" ]] && tar --remove-files -zcf ${{ inputs.deploy-host-backup-path }}/${{ github.sha }}.tar.gz -C ${{ inputs.deploy-host-backup-path }} ${{ github.sha }}
+        script: ${{inputs.deploy-host-backup-path }} != "" && tar --remove-files -zcf ${{ inputs.deploy-host-backup-path }}/${{ github.sha }}.tar.gz -C ${{ inputs.deploy-host-backup-path }} ${{ github.sha }}
         host: ${{ inputs.deploy-host }}
         username: ${{ inputs.deploy-host-user }}
         key: ${{ inputs.deploy-host-user-key }}
@@ -120,7 +120,7 @@ runs:
     - name: Delete backups older than 7 days.
       uses: appleboy/ssh-action@v0.1.4
       with:
-        script: [[ "${{inputs.deploy-host-backup-path}}" != "" ]] && find ${{ inputs.deploy-host-backup-path }} -type f -mtime +7 -name '*.tar.gz' -delete
+        script: ${{ inputs.deploy-host-backup-path }}" != "" && find ${{ inputs.deploy-host-backup-path }} -type f -mtime +7 -name '*.tar.gz' -delete
         host: ${{ inputs.deploy-host }}
         username: ${{ inputs.deploy-host-user }}
         key: ${{ inputs.deploy-host-user-key }}

--- a/3.0/action.yml
+++ b/3.0/action.yml
@@ -13,7 +13,7 @@ inputs:
     required: true
   deploy-host-backup-path:
     description: Backup path for changed and deleted files after rsync deploy.
-    required: true
+    required: false
   deploy-host-user:
     description: Username of the rsync deployment.
     required: true
@@ -111,7 +111,7 @@ runs:
     - name: Compress backup files.
       uses: appleboy/ssh-action@v0.1.4
       with:
-        script: tar --remove-files -zcf ${{ inputs.deploy-host-backup-path }}/${{ github.sha }}.tar.gz -C ${{ inputs.deploy-host-backup-path }} ${{ github.sha }}
+        script: [[ "${{inputs.deploy-host-backup-path}}" != "" ]] && tar --remove-files -zcf ${{ inputs.deploy-host-backup-path }}/${{ github.sha }}.tar.gz -C ${{ inputs.deploy-host-backup-path }} ${{ github.sha }}
         host: ${{ inputs.deploy-host }}
         username: ${{ inputs.deploy-host-user }}
         key: ${{ inputs.deploy-host-user-key }}

--- a/3.0/action.yml
+++ b/3.0/action.yml
@@ -120,7 +120,7 @@ runs:
     - name: Delete backups older than 7 days.
       uses: appleboy/ssh-action@v0.1.4
       with:
-        script: find ${{ inputs.deploy-host-backup-path }} -type f -mtime +7 -name '*.tar.gz' -delete
+        script: [[ "${{inputs.deploy-host-backup-path}}" != "" ]] && find ${{ inputs.deploy-host-backup-path }} -type f -mtime +7 -name '*.tar.gz' -delete
         host: ${{ inputs.deploy-host }}
         username: ${{ inputs.deploy-host-user }}
         key: ${{ inputs.deploy-host-user-key }}


### PR DESCRIPTION
Make the parameter deploy-host-backup-path optional, and check if it's set in the "Compress backup files" script.