### PR TITLE
Add dependency checker. Pass lite argument to build.php

### DIFF
--- a/3.0/action.yml
+++ b/3.0/action.yml
@@ -76,6 +76,10 @@ runs:
       run: composer install --prefer-dist --no-progress --no-suggest
       shell: bash
 
+    - name: Run composer dependency checks
+      run: php ./buildDependencyChecker.php
+      shell: bash
+
     - name: Inject access token in .npmrc.
       run: | 
         echo "@helsingborg-stad:registry=https://npm.pkg.github.com/helsingborg-stad" >> ~/.npmrc
@@ -90,7 +94,7 @@ runs:
       shell: bash
 
     - name: Execute buildscripts in themes and plugins folders.
-      run: php ./build.php --cleanup
+      run: php ./build.php --cleanup --lite
       shell: bash
 
     - name: Cleanup .npmrc

--- a/3.0/action.yml
+++ b/3.0/action.yml
@@ -94,7 +94,7 @@ runs:
       shell: bash
 
     - name: Execute buildscripts in themes and plugins folders.
-      run: php ./build.php --cleanup --lite
+      run: php ./build.php --cleanup --no-composer-in-child-packages
       shell: bash
 
     - name: Cleanup .npmrc


### PR DESCRIPTION
Lite: Install all dependencys in master repository, do not install plugins with composer.