### PR TITLE
Use latest node version for better security and long term support

### DIFF
--- a/4.0/action.yml
+++ b/4.0/action.yml
@@ -168,7 +168,7 @@ runs:
 
     - uses: actions/setup-node@v3
       with:
-        node-version: 16.13.2
+        node-version: 22.15.0
 
     - name: Setup PHP with composer v2.
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
I haven't tried this with the absolute latest version of Municipio but with 5.2.3. Would be great if you guys tried in your staging environment as well.

Used in conjunction with https://github.com/municipio-se/municipio-deployment